### PR TITLE
Add Jax installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,13 @@ Python 3.9.13
 #### PyTorch
 
 ```console
-(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=11.6 -c pytorch -c conda-forge
+```
+
+#### Jax
+
+```console
+(myenv) you@master:~ $ conda install jax cuda-nvcc=11.7 -c conda-forge -c nvidia
 ```
 
 #### TensorFlow

--- a/README.md
+++ b/README.md
@@ -11,31 +11,6 @@ Documentation and guidelines for the Alan GPU cluster at the University of Lièg
 - [Submit an issue](https://github.com/montefiore-ai/alan-cluster/issues/new?assignees=JoeriHermans&labels=bug&template=issue-report.md&title=%5BIssue%5D+TODO)
 - [Access JupyterHub](https://alan.montefiore.uliege.be/jupyter/)
 
----
-
-Table of contents:
-- [General actions](#general-actions)
-- [User account setup](#user-account-setup)
-  - [Connecting to Alan](#connecting-to-alan)
-  - [Preparing an Anaconda environment](#preparing-an-anaconda-environment)
-  - [Preparing your (Deep Learning) project](#preparing-your-deep-learning-project)
-    - [PyTorch](#pytorch)
-    - [TensorFlow](#tensorflow)
-  - [Transferring your datasets to Alan](#transferring-your-datasets-to-alan)
-- [Cluster usage](#cluster-usage)
-  - [Slurm commands](#slurm-commands)
-  - [Partitions](#partitions)
-  - [Filesystems](#filesystems)
-  - [Recommended ways to load data into the GPU](#recommended-ways-to-load-data-into-the-gpu)
-    - [My dataset does not fit in memory](#my-dataset-does-not-fit-in-memory)
-    - [My dataset fits in memory](#my-dataset-fits-in-memory)
-- [Cluster-wide datasets](#cluster-wide-datasets)
-- [Centralised Jupyter Access](#centralised-jupyter-access)
-    - [Accessing Jupyter Lab](#is-it-possible-to-access-jupyter-lab)
-    - [Launching multiple servers](#launching-multiple-servers)
-
----
-
 ## User account setup
 
 If you do not have an account, then first [request an account](https://alan.montefiore.uliege.be/register) to the GPU cluster.
@@ -43,92 +18,95 @@ If you do not have an account, then first [request an account](https://alan.mont
 ### Connecting to Alan
 
 Once you have been provided with your account details by e-mail, you can connect to Alan through SSH:
-
 ```console
 you@local:~ $ ssh you@master.alan.priv
 ```
 After logging in with the password provided by the account confirmation e-mail, you will be forced to change the password.
 
-The e-mail will additionally contain a private authentication key which can be used to connect to the GPU cluster.
-The key can be used by manually executing:
+The e-mail will additionally contain a private authentication key which can be used to connect to the GPU cluster. The key can be used by manually executing:
 ```console
-you@local:~ $ ssh -i /path/to/privatekey/alan you@master.alan.priv
+you@local:~ $ ssh -i path/to/privatekey you@master.alan.priv
 ```
-Likewise, the authentication procedure can be automated by moving the private key
+The authentication procedure can be automated by moving the private key
 ```console
-you@local:~ $ cp /path/to/privatekey/alan ~/.ssh/alan
-you@local:~ $ chmod 400 ~/.ssh/alan
+you@local:~ $ cp path/to/privatekey ~/.ssh/id_alan
+you@local:~ $ chmod 400 ~/.ssh/id_alan
 ```
 and adding
-```bash
+```
 Host alan
   HostName master.alan.priv
-  IdentityFile ~/.ssh/alan
+  User you
+  IdentityFile ~/.ssh/id_alan
 ```
-to `.ssh/config`.
-
+to `~/.ssh/config`.
 
 ### Preparing an Anaconda environment
 
-On your initial login, we will guide you to automatically install an Anaconda environment. **Carefully** read the instructions.
-If you cancelled the installation procedure, you can still setup Anaconda by executing:
-
-> **Recommended**. **This installs a Python 3 environment by default.**
+On your initial login, we will guide you to automatically install an Anaconda environment. **Carefully** read the instructions. If you cancelled the installation procedure, you can still setup Anaconda by executing:
 
 ```console
-you@alan-master:~ $ wget https://repo.anaconda.com/archive/Anaconda3-2020.07-Linux-x86_64.sh
-you@alan-master:~ $ sh Anaconda3-2020.07-Linux-x86_64.sh
+you@master:~ $ wget https://repo.anaconda.com/archive/Anaconda3-2020.07-Linux-x86_64.sh
+you@master:~ $ sh Anaconda3-2020.07-Linux-x86_64.sh
 ```
 
 ### Preparing your (Deep Learning) project
 
-The installation of your Deep Learning environment is quite straightforward after Anaconda has been configured. In general we recommend to work with [environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) on a per-project basis. This is generally good practice as it allows for more convenient reproducability of your experiments.
+The installation of your Deep Learning environment is quite straightforward after Anaconda has been configured. In general we recommend to work with [environments](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) on a per-project basis as it allows for better encapsulation and reproducibility of your experiments.
+
+```console
+you@master:~ $ conda create -n myenv python=3.9
+you@master:~ $ conda activate myenv
+(myenv) you@master:~ $ python --version
+Python 3.9.13
+```
 
 #### PyTorch
 
 ```console
-you@alan-master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+```
+
+#### Jax
+
+```console
+(myenv) you@master:~ $ conda install jax cuda-nvcc -c conda-forge -c nvidia
 ```
 
 #### TensorFlow
 
-> **Attention**. Install `tensorflow-gpu` to use `tensorflow` on the GPU's! The same holds for `keras-gpu`.
-
 ```console
-you@alan-master:~ $ conda install tensorflow-gpu
+(myenv) you@master:~ $ conda install tensorflow-gpu
 ```
 
 ### Transferring your datasets to Alan
 
 This section shows you how to transfer your datasets to the GPU cluster. It is a good practice to centralize your datasets in a common folder:
-
 ```console
-you@alan-master:~ $ mkdir datasets
-you@alan-master:~ $ cd datasets
+you@master:~ $ mkdir -p path/to/datasets
+you@master:~ $ cd path/to/datasets
 ```
 
-The transfer is initiated using `scp` from the machine storing the data (e.g., your desktop computer) to the cluster:
-
+The transfer is initiated using `scp` from the machine storing the data (e.g. your desktop computer) to the cluster:
 ```console
-you@local:~ $ scp -r my_amazing_dataset you@master.alan.priv:/location/of/datasets/
+you@local:~ $ scp -r my_dataset alan:path/to/datasets
 ```
 
 Alternatively, one can rely on `rsync`:
-
 ```console
-you@local:~ $ rsync -r -v --progress my_amazing_dataset -e ssh you@master.alan.priv:/location/of/datasets/
+you@local:~ $ rsync -r -v --progress my_dataset -e ssh alan:path/to/datasets
 ```
 
 ## Cluster usage
 
 The CECI cluster documentation features a [thorough Slurm guide](https://support.ceci-hpc.be/doc/_contents/QuickStart/SubmittingJobs/SlurmTutorial.html). Read it carefully before using Alan.
 
-Elementary tutorials can also be found in [`/tutorials/`](https://github.com/montefiore-ai/alan-cluster/tree/master/tutorials). Read them to get started quickly.
+Elementary tutorials can also be found in [`/tutorials`](tutorials). Read them to get started quickly.
 
 ### Slurm commands
 
 - [`sbatch`](https://slurm.schedmd.com/sbatch.html): submit a job to the cluster.
-  - To reserve GPU(s) add `--gres=gpu:N_GPUS` to `sbatch`.
+  - To reserve `N` GPU(s) add `--gres=gpu:N` to `sbatch`.
 - [`scancel`](https://slurm.schedmd.com/scancel.html): cancel queued or running jobs.
 - [`srun`](https://slurm.schedmd.com/srun.html): launch a job step.
 - [`squeue`](https://slurm.schedmd.com/squeue.html): display jobs currently in the queue and their associated metadata.
@@ -137,13 +115,14 @@ Elementary tutorials can also be found in [`/tutorials/`](https://github.com/mon
 - [`seff`](https://bugs.schedmd.com/show_bug.cgi?id=1611): resource utilization efficiency of the specified job.
 
 ### Partitions
+
 The cluster provides several queues or job partitions. We made the design decision to partition the job queues based on the GPU type: `1080ti` (GTX 1080 Ti), `2080ti` (RTX 2080 Ti), `quadro` (Quadro RTX 6000) and `tesla` (Tesla V100). This enables the user to specifically request specific GPUs depending on her needs. A specific job partition can be requested by specifying `--partition=<partition>` to the `sbatch` command or in your submission script. If no partition is specified, then a job will be scheduled where resources are available.
 
 For debugging purposes, e.g. if you would like to quickly test your script, you can also make use of the `debug` partition by specifying `--partition=debug`. This partition has a maximum execution time of 15 minutes.
 
 A full overview of the available partitions is shown below.
 ```console
-root@master:~ sinfo -s
+you@master:~ $ sinfo -s
 PARTITION       AVAIL  TIMELIMIT   NODELIST
 all*               up 14-00:00:0   compute-[01-04,06-13]
 debug              up      15:00   compute-05
@@ -153,30 +132,29 @@ quadro             up 14-00:00:0   compute-[11-12]
 tesla              up 14-00:00:0   compute-13
 priority-quadro    up 14-00:00:0   compute-[11-12]
 priority-tesla     up 14-00:00:0   compute-13
+priority           up 14-00:00:0   compute-[01-04,06-13]
 ```
 The high-priority partitions `priority-quadro` and `priority-tesla` can be used to request either Quadro RTX 6000 or Tesla V100 GPUs while flagging your job as high priority in the job queue. This privilege is only available to some users. The `quadro` and `tesla` partitions can be requested by all users, but the priority of the corresponding jobs will be kept as normal.
 
 Your priority status can be obtained by executing:
 ```console
-you@master:~ sacctmgr show assoc | grep $USER | grep priority > /dev/null && echo "Allowed" || echo "Not allowed"
+you@master:~ $ sacctmgr show assoc | grep $USER | grep priority > /dev/null && echo "allowed" || echo "not allowed"
 ```
 
 ### Filesystems
 
 We provide the following filesystems to the user.
 
-| Mountpoint             	| Name                     	| Capacity 	| Purpose                                                                                                                            	| Load data to GPU from filesystem?                                                                                                                	| Data persistance   	|
-|------------------------	|--------------------------	|----------	|------------------------------------------------------------------------------------------------------------------------------------	|--------------------------------------------------------------------------------------------------------------------------------------------------	|--------------------	|
-| `/home/$USER`          	| Home directory           	| 11TB     	| Hosts your main files and binaries.                                                                                                	| Only if the dataset fits in memory. Do not use this endpoint if your jobs perform a lot of random I/O.                                        	| :heavy_check_mark: 	|
-| `/scratch/users/$USER` 	| Global scratch directory 	| 65TB     	| Global decentralized filesystem. Store your datasets here if they do not fit in memory, or if it consists of a lot of small files. 	| Yes                                                                                                                                              	| :x:                	|
+| Mountpoint             | Name                     | Capacity | Purpose                                                                                                                            | Load data to GPU from filesystem?                                                                      | Data persistance   |
+|------------------------|--------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------|
+| `/home/$USER`          | Home directory           | 11TB     | Hosts your main files and binaries.                                                                                                | Only if the dataset fits in memory. Do not use this endpoint if your jobs perform a lot of random I/O. | :heavy_check_mark: |
+| `/scratch/users/$USER` | Global scratch directory | 65TB     | Global decentralized filesystem. Store your datasets here if they do not fit in memory, or if it consists of a lot of small files. | Yes                                                                                                    | :x:                |
 
-Data persistance is only guaranteed on `/home/$USER`. Backing-up data hosted on `/scratch` is your responsibility. As a result, the results of a computation should preferably stored in `/home/$USER`.
+Data persistance is only guaranteed on `/home/$USER`. Backing-up data hosted on `/scratch` is your responsibility. The results of a computation should preferably stored in `/home/$USER`.
 
 ### Recommended ways to load data into the GPU
 
-It is generally not recommended to load small batches from the main storage disk because most of Deep Learning requires (small) random batches.
-This translates into a lot of random IO operations on the main storage *hard disks* of the cluster,
-which in turn degrades the performance of all jobs. We recommend the following ways to load data into the GPU:
+It is generally not recommended to load small batches from the main storage disk. This translates into a lot of random IO operations on the main storage *hard disks* of the cluster, which in turn degrades the performance of all jobs. We recommend the following ways to load data into the GPU:
 
 #### My dataset does not fit in memory
 
@@ -188,10 +166,9 @@ In this case, we recommend to simply read the dataset into memory and load your 
 
 ## Cluster-wide datasets
 
-At the moment we provide the following cluster-wide, **read-only** datasets which are accessible at `/data/datasets`:
-
+At the moment we provide the following cluster-wide, **read-only** datasets which are accessible at `/scratch/datasets`:
 ```console
-you@alan-master:~ $ ls -al /scratch/datasets
+you@master:~ $ ls -l /scratch/datasets
 ```
 
 If you would like to propose a new cluster-wide dataset, feel free to [submit a proposal](https://github.com/montefiore-ai/alan-cluster/issues/new?assignees=JoeriHermans&labels=enhancement&template=feature-request.md&title=%5BFeature+Request%5D+TODO).
@@ -208,13 +185,12 @@ Launching kernels within existing environments is possible. No additional config
 ### Is it possible to access Jupyter Lab?
 
 Yes, simply change the `tree` keyword in the URL to `lab`. For instance
-
 ```
-https://alan.montefiore.uliege.be/jupyter/user/jhermans/tree
+https://alan.montefiore.uliege.be/jupyter/user/you/tree
 ```
 becomes
 ```
-https://alan.montefiore.uliege.be/jupyter/user/jhermans/lab
+https://alan.montefiore.uliege.be/jupyter/user/you/lab
 ```
 
 ### Launching multiple servers

--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ Python 3.9.13
 #### PyTorch
 
 ```console
-(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=11.3 -c pytorch
 ```
 
 #### Jax
 
 ```console
-(myenv) you@master:~ $ conda install jax cuda-nvcc -c conda-forge -c nvidia
+(myenv) you@master:~ $ conda install cudatoolkit=11.3 cuda-nvcc -c default -c nvidia
+(myenv) you@master:~ $ pip install jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 ```
 
 #### TensorFlow

--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ Documentation and guidelines for the Alan GPU cluster at the University of Lièg
 - [Submit an issue](https://github.com/montefiore-ai/alan-cluster/issues/new?assignees=JoeriHermans&labels=bug&template=issue-report.md&title=%5BIssue%5D+TODO)
 - [Access JupyterHub](https://alan.montefiore.uliege.be/jupyter/)
 
+---
+
+Table of contents:
+- [General actions](#general-actions)
+- [User account setup](#user-account-setup)
+  - [Connecting to Alan](#connecting-to-alan)
+  - [Preparing an Anaconda environment](#preparing-an-anaconda-environment)
+  - [Preparing your (Deep Learning) project](#preparing-your-deep-learning-project)
+    - [PyTorch](#pytorch)
+    - [TensorFlow](#tensorflow)
+  - [Transferring your datasets to Alan](#transferring-your-datasets-to-alan)
+- [Cluster usage](#cluster-usage)
+  - [Slurm commands](#slurm-commands)
+  - [Partitions](#partitions)
+  - [Filesystems](#filesystems)
+  - [Recommended ways to load data into the GPU](#recommended-ways-to-load-data-into-the-gpu)
+    - [My dataset does not fit in memory](#my-dataset-does-not-fit-in-memory)
+    - [My dataset fits in memory](#my-dataset-fits-in-memory)
+- [Cluster-wide datasets](#cluster-wide-datasets)
+- [Centralised Jupyter Access](#centralised-jupyter-access)
+    - [Accessing Jupyter Lab](#is-it-possible-to-access-jupyter-lab)
+    - [Launching multiple servers](#launching-multiple-servers)
+
+---
+
 ## User account setup
 
 If you do not have an account, then first [request an account](https://alan.montefiore.uliege.be/register) to the GPU cluster.
@@ -46,8 +71,8 @@ to `~/.ssh/config`.
 On your initial login, we will guide you to automatically install an Anaconda environment. **Carefully** read the instructions. If you cancelled the installation procedure, you can still setup Anaconda by executing:
 
 ```console
-you@master:~ $ wget https://repo.anaconda.com/archive/Anaconda3-2020.07-Linux-x86_64.sh
-you@master:~ $ sh Anaconda3-2020.07-Linux-x86_64.sh
+you@master:~ $ wget https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh
+you@master:~ $ sh Anaconda3-2022.05-Linux-x86_64.sh
 ```
 
 ### Preparing your (Deep Learning) project
@@ -64,14 +89,7 @@ Python 3.9.13
 #### PyTorch
 
 ```console
-(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=11.3 -c pytorch
-```
-
-#### Jax
-
-```console
-(myenv) you@master:~ $ conda install cudatoolkit=11.3 cuda-nvcc -c default -c nvidia
-(myenv) you@master:~ $ pip install jax[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 ```
 
 #### TensorFlow

--- a/tutorials/mnist/README.md
+++ b/tutorials/mnist/README.md
@@ -1,12 +1,10 @@
 # Running a Deep Learning job 
 
-This short tutorial will guide you on how to run your first Deep Learning job on Alan.
-
-**Attention:** This document assumes you have an Anaconda environment configured with PyTorch.
+This short tutorial will guide you on how to run your first Deep Learning job on Alan. This document assumes you have an Anaconda environment configured with PyTorch.
 
 ```console
-you@alan-master:~ $ conda activate myenvironment
-you@alan-master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+you@master:~ $ conda activate myenv
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
 ```
 
 ## Training a Convolutional network on MNIST
@@ -15,9 +13,9 @@ You have just followed the last lecture of INFO8010 and you are now ready to tra
 
 ## Scheduling your job
 
-Jobs are scheduled on Alan through Slurm scripts. They specify the resources you are requesting to execute your job, as well as the sequence of instructions you want to execute. In the Slurm script `mnist.sbatch` below, we allocate 2 CPUs et 1 GPU and specify the Python script we want to run on the cluster. 
+Jobs are scheduled on Alan through Slurm scripts. They specify the resources you are requesting to execute your job, as well as the sequence of instructions you want to execute. In the Slurm script `mnist.sbatch` below, we allocate 2 CPUs and 1 GPU and specify the Python script we want to run on the cluster.
 
-```console
+```bash
 #!/usr/bin/env bash
 #
 # Slurm arguments
@@ -32,32 +30,29 @@ Jobs are scheduled on Alan through Slurm scripts. They specify the resources you
 #
 
 # Activate your Anaconda environment
-conda activate myenvironment         # CHANGEME
+conda activate myenv # CHANGEME
 
 # Run your Python script
-cd /home/you/mnist  # CHANGEME
+cd path/to/mnist # CHANGEME
 python mnist.py
 ```
 
 After your resources have been properly configured, your PyTorch script is ready to be scheduled by Slurm:
 ```console
-you@alan-master:~ $ sbatch mnist.sbatch
+you@master:~ $ sbatch mnist.sbatch
 Submitted batch job 1346061
 ```
 
 You can check the scheduling queue using the `squeue` command. It tells you about the jobs that are pending for resources and indicates those currently running:
-
 ```console
-you@alan-master:~ $ squeue
+you@master:~ $ squeue --user $USER
              JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-               ...
-           1346061       all    mnist  glouppe  R       0:07      1 alan-compute-02
+           1346061       all    mnist      you  R       0:07      1 compute-02
 ```
 
 The ouput file of the execution will be written to `mnist/mnist-output.log`:
-
 ```console
-you@alan-master:~ $ more mnist/mnist-output.log 
+you@master:~ $ more mnist/mnist-output.log
 Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to ../data/MNIST/raw/train-images-idx3-ubyte.gz
 Extracting ../data/MNIST/raw/train-images-idx3-ubyte.gz to ../data/MNIST/raw
 Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz to ../data/MNIST/raw/train-labels-idx1-ubyte.gz

--- a/tutorials/mnist/README.md
+++ b/tutorials/mnist/README.md
@@ -4,7 +4,7 @@ This short tutorial will guide you on how to run your first Deep Learning job on
 
 ```console
 you@master:~ $ conda activate myenv
-(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=10.2 -c pytorch
+(myenv) you@master:~ $ conda install pytorch torchvision cudatoolkit=11.6 -c pytorch -c conda-forge
 ```
 
 ## Training a Convolutional network on MNIST

--- a/tutorials/mnist/mnist.sbatch
+++ b/tutorials/mnist/mnist.sbatch
@@ -12,8 +12,8 @@
 #
 
 # Activate your Anaconda environment
-conda activate myenvironment        # CHANGEME
+conda activate myenv # CHANGEME
 
 # Run your Python script
-cd /home/username/sandbox/mnist     # CHANGEME
+cd path/to/mnist # CHANGEME
 python mnist.py

--- a/tutorials/notebooks/README.md
+++ b/tutorials/notebooks/README.md
@@ -2,8 +2,8 @@
 
 This tutorial will guide you on how to setup your personalized Jupyter instance on the GPU cluster. This document assumes you have an Anaconda environment configured with Jupyter Lab.
 ```console
-you@alan-master:~ $ conda activate myenvironment
-you@alan-master:~ $ conda install jupyterlab
+you@master:~ $ conda activate myenv
+(myenv) you@master:~ $ conda install jupyterlab
 ```
 
 **Attention:** This document only provides a setup to use Jupyter *interactively*. If you simply would like to execute notebooks to summarize results, please have a look at [Papermill](https://github.com/nteract/papermill).
@@ -14,14 +14,14 @@ you@alan-master:~ $ conda install jupyterlab
 
 A first prerequisite is the notebook configuration file and can be generated as follows:
 ```console
-you@alan-master:~ $ jupyter notebook --generate-config
+(myenv) you@master:~ $ jupyter notebook --generate-config
 ```
 This operation will write a new default config to your home directory.
 
 Since the notebook server will be allocated on a compute node by Slurm, and is publicly available to everyone on the internal ULG network, it is good practice to secure your instance with a password.
 ```console
-you@alan-master:~ $ jupyter notebook password
-Enter password:  ****
+(myenv) you@master:~ $ jupyter notebook password
+Enter password: ****
 Verify password: ****
 ```
 You will only have to execute this once, as the password will be shared across all the Juypter servers you will allocate.
@@ -29,7 +29,7 @@ You will only have to execute this once, as the password will be shared across a
 ## Resource allocation
 The default Slurm submission script can be obtained by:
 ```console
-you@alan-master:~ $ wget https://raw.githubusercontent.com/montefiore-ai/alan-cluster/master/tutorials/notebooks/jupyter.sbatch
+you@master:~ $ wget https://raw.githubusercontent.com/montefiore-ai/alan-cluster/master/tutorials/notebooks/jupyter.sbatch
 ```
 The resource allocation of your server can be controlled by changing the parameters in `jupyter.sbatch` and can be found at the top of the submission file.
 ```bash
@@ -47,32 +47,29 @@ The resource allocation of your server can be controlled by changing the paramet
 #
 
 # Activate the Anaconda environment in which to execute the Jupyter instance.
-conda activate myenvironment     # CHANGEME
+conda activate myenv # CHANGEME
 
 # Start Jupyter Lab
 jupyter lab --ip='*' --no-browser
 ```
 Please make sure you change the Anaconda environment in the submission file. By default is set to `myenvironment`. After your resources have been properly configured, the Jupyter instance is ready to be scheduled by Slurm:
 ```console
-you@alan-master:~ $ sbatch jupyter.sbatch
+you@master:~ $ sbatch jupyter.sbatch
 Submitted batch job 1333969
 ```
 
 ## Accessing the Jupyter server
 
-After the Jupyter instance has been scheduled by Slurm, i.e., it is in a running state:
+After the Jupyter instance has been scheduled by Slurm, i.e. it is in a running state:
 ```console
-you@alan-master:~ $ squeue | grep you | grep JUPYTER
+you@master:~ $ squeue --user $USER | grep JUPYTER
 ```
 The IP address and port allocated to your Jupyter instance can be extracted from the log file, as specified above.
 ```console
-you@alan-master:~ $ cat jupyter.log | grep compute
+you@master:~ $ cat jupyter.log | grep compute
 [I 17:00:28.508 LabApp] http://compute-05:8888/
 ```
-The address in conjunction with the ealier defined password can be used to access the Jupyter instance through your browser.
-Remember the addess `compute-05` is only defined within the domain of the cluster (`alan.priv`). You therefore have to access
-the instance using the addess `http://compute-05.alan.priv:8888/`, 
-assuming you are connected to the ULiège internal network (e.g., through the VPN or some other service). The server can be terminated through the browser or via the `scancel` command.
+The address in conjunction with the ealier defined password can be used to access the Jupyter instance through your browser. Remember the addess `compute-05` is only defined within the domain of the cluster (`alan.priv`). You therefore have to access the instance using the addess `http://compute-05.alan.priv:8888/`, assuming you are connected to the ULiège internal network (e.g., through the VPN or some other service). The server can be terminated through the browser or via the `scancel` command.
 
 ## Advanced options
 

--- a/tutorials/notebooks/README.md
+++ b/tutorials/notebooks/README.md
@@ -52,7 +52,7 @@ conda activate myenv # CHANGEME
 # Start Jupyter Lab
 jupyter lab --ip='*' --no-browser
 ```
-Please make sure you change the Anaconda environment in the submission file. By default is set to `myenvironment`. After your resources have been properly configured, the Jupyter instance is ready to be scheduled by Slurm:
+Please make sure you change the Anaconda environment in the submission file. By default is set to `myenv`. After your resources have been properly configured, the Jupyter instance is ready to be scheduled by Slurm:
 ```console
 you@master:~ $ sbatch jupyter.sbatch
 Submitted batch job 1333969
@@ -69,7 +69,7 @@ The IP address and port allocated to your Jupyter instance can be extracted from
 you@master:~ $ cat jupyter.log | grep compute
 [I 17:00:28.508 LabApp] http://compute-05:8888/
 ```
-The address in conjunction with the ealier defined password can be used to access the Jupyter instance through your browser. Remember the addess `compute-05` is only defined within the domain of the cluster (`alan.priv`). You therefore have to access the instance using the addess `http://compute-05.alan.priv:8888/`, assuming you are connected to the ULiège internal network (e.g., through the VPN or some other service). The server can be terminated through the browser or via the `scancel` command.
+The address in conjunction with the earlier defined password can be used to access the Jupyter instance through your browser. Remember the address `compute-05` is only defined within the domain of the cluster (`alan.priv`). You therefore have to access the instance using the address `http://compute-05.alan.priv:8888/`, assuming you are connected to the ULiège internal network (e.g., through the VPN or some other service). The server can be terminated through the browser or via the `scancel` command.
 
 ## Advanced options
 

--- a/tutorials/notebooks/jupyter.sbatch
+++ b/tutorials/notebooks/jupyter.sbatch
@@ -12,7 +12,7 @@
 #
 
 # Activate the Anaconda environment in which to execute the Jupyter instance.
-conda activate myenvironment # CHANGEME
+conda activate myenv # CHANGEME
 
 # Start Jupyter Lab
 jupyter lab --ip='*' --no-browser


### PR DESCRIPTION
The `conda-forge` version of `jax` does not work. Instead, we install the `cudatoolkit=11.3` and `nvcc` with `conda` and then `jax[cuda]` with `pip`. Since the cluster has CUDA 11.0 installed, we need to check whether `cudatoolkit=11.3` is a problem although it seems to work fine for basic operations.

Additionally, update console code blocks (mainly `@alan-master` to `@master` as it is the name of the master node) and remove the table of contents as it is now built-in GitHub's markdown viewer.

> Edit: https://docs.nvidia.com/deeplearning/cudnn/support-matrix shows that CUDA 11.0 is compatible with toolkit 11.3.

