### PR TITLE
Clarify Mountpoint tableau

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,12 @@ We provide the following filesystems to the user.
 
 | Mountpoint             | Name                     | Capacity | Purpose                                                                                                                            | Load data to GPU from filesystem?                                                                      | Data persistance   |
 |------------------------|--------------------------|----------|------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|--------------------|
-| `/home/$USER`          | Home directory           | 11TB     | Hosts your main files and binaries.                                                                                                | Only if the dataset fits in memory. Do not use this endpoint if your jobs perform a lot of random I/O. | :heavy_check_mark: |
-| `/scratch/users/$USER` | Global scratch directory | 65TB     | Global decentralized filesystem. Store your datasets here if they do not fit in memory, or if it consists of a lot of small files. | Yes                                                                                                    | :x:                |
+| `/home/`          | Home directory           | 11TB     | Hosts your main files and binaries.                                                                                                | Only if the dataset fits in memory. Do not use this endpoint if your jobs perform a lot of random I/O. | :heavy_check_mark: |
+| `/scratch/users/` | Global scratch directory | 65TB     | Global decentralized filesystem. Store your datasets here if they do not fit in memory, or if it consists of a lot of small files. | Yes                                                                                                    | :x:                |
 
 Data persistance is only guaranteed on `/home/$USER`. Backing-up data hosted on `/scratch` is your responsibility. The results of a computation should preferably stored in `/home/$USER`.
+
+The persistence in the `/scratch/users` partition is up to a couple of months.
 
 ### Recommended ways to load data into the GPU
 


### PR DESCRIPTION
Based on feedback from multiple users, the use of `$USER` created confusion regarding the 11TB storage allocation. The confusion is about whether it referred to the entire `/home/` partition or to each individual user's `/home/$USER` directory. This change serves to clarify that distinction.

The addition of file persistence for the `/scratch/` partition has been introduced for users, as some systems provides only 24 hours of persistence for example.